### PR TITLE
Add support for Tasmota 6.4.1 Firmware

### DIFF
--- a/index.js
+++ b/index.js
@@ -395,7 +395,7 @@ function MqttPowerConsumptionTasmotaAccessory(log, config) {
 			that.activeStat = status == that.activityParameter;
 			that.service.setCharacteristic(Characteristic.StatusActive, that.activeStat);
 		} else if (topic == that.topics.stateGet) {
-			data = null;
+			var data = null;
 			try {
 			  data = JSON.parse(message);
 			}

--- a/index.js
+++ b/index.js
@@ -300,34 +300,37 @@ function MqttPowerConsumptionTasmotaAccessory(log, config) {
 			catch (e) {
 			  that.log("JSON problem");
 			}
-			// Update based on Tasmota 6.4.1 tele/sonoff/SENSOR JSON response
-			if ((data === null) || !data.hasOwnProperty("ENERGY")) {
+			if (data === null) {
 				return null
 			}
-			if (data["ENERGY"].hasOwnProperty("Power")) {
-				that.powerConsumption = parseFloat(data["ENERGY"].Power);
+			if (data.hasOwnProperty("ENERGY")) {
+				// Update based on Tasmota 6.4.1 tele/sonoff/SENSOR JSON response
+				data = data["ENERGY"]
+			}
+			if (data.hasOwnProperty("Power")) {
+				that.powerConsumption = parseFloat(data.Power);
 				that.service.setCharacteristic(EvePowerConsumption, that.powerConsumption);
 			} else {
 				return null
 			}
 			that.lastPeriodNewData = that.lastHourNewData = that.todayNewData = true;
-			if (data["ENERGY"].hasOwnProperty("Factor")) {
-				that.powerFactor = parseFloat(data["ENERGY"].Factor);
+			if (data.hasOwnProperty("Factor")) {
+				that.powerFactor = parseFloat(data.Factor);
 				that.powerConsumptionAV = that.powerFactor > 0 ? that.powerConsumption / that.powerFactor : 0;
 				that.service.setCharacteristic(EvePowerConsumptionVA, that.powerConsumptionAV);
 			}
-			if (data["ENERGY"].hasOwnProperty("Voltage")) {
-				that.voltage = parseFloat(data["ENERGY"].Voltage);
+			if (data.hasOwnProperty("Voltage")) {
+				that.voltage = parseFloat(data.Voltage);
 				that.service.setCharacteristic(EveVolts, that.voltage);
 			}
-			if (data["ENERGY"].hasOwnProperty("Current")) {
-				that.amperage = parseFloat(data["ENERGY"].Current);
+			if (data.hasOwnProperty("Current")) {
+				that.amperage = parseFloat(data.Current);
 				that.outletNowInUse = that.outletUseByCurrent ? (that.amperage > that.outletInUseCurrent) : true
 
 				that.service.setCharacteristic(EveAmperes, that.amperage);
 				that.service.setCharacteristic(Characteristic.OutletInUse, that.outletNowInUse);
 			}
-			that.todaykWh = data["ENERGY"].hasOwnProperty("Today") ? parseFloat(data["ENERGY"].Today) : -1;
+			that.todaykWh = data.hasOwnProperty("Today") ? parseFloat(data.Today) : -1;
 			// Preserve power data
 			if (that.patchToSave) {
 				that.fs.readFile(that.patchToSave + that.filename + "_powerTMP.txt", "utf8", function(err, data) {

--- a/index.js
+++ b/index.js
@@ -300,33 +300,34 @@ function MqttPowerConsumptionTasmotaAccessory(log, config) {
 			catch (e) {
 			  that.log("JSON problem");
 			}
-			if (data === null) {
+			// Update based on Tasmota 6.4.1 tele/sonoff/SENSOR JSON response
+			if ((data === null) || !data.hasOwnProperty("ENERGY")) {
 				return null
 			}
-			if (data.hasOwnProperty("Power")) {
-				that.powerConsumption = parseFloat(data.Power);
+			if (data["ENERGY"].hasOwnProperty("Power")) {
+				that.powerConsumption = parseFloat(data["ENERGY"].Power);
 				that.service.setCharacteristic(EvePowerConsumption, that.powerConsumption);
 			} else {
 				return null
 			}
 			that.lastPeriodNewData = that.lastHourNewData = that.todayNewData = true;
-			if (data.hasOwnProperty("Factor")) {
-				that.powerFactor = parseFloat(data.Factor);
+			if (data["ENERGY"].hasOwnProperty("Factor")) {
+				that.powerFactor = parseFloat(data["ENERGY"].Factor);
 				that.powerConsumptionAV = that.powerFactor > 0 ? that.powerConsumption / that.powerFactor : 0;
 				that.service.setCharacteristic(EvePowerConsumptionVA, that.powerConsumptionAV);
 			}
-			if (data.hasOwnProperty("Voltage")) {
-				that.voltage = parseFloat(data.Voltage);
+			if (data["ENERGY"].hasOwnProperty("Voltage")) {
+				that.voltage = parseFloat(data["ENERGY"].Voltage);
 				that.service.setCharacteristic(EveVolts, that.voltage);
 			}
-			if (data.hasOwnProperty("Current")) {
-				that.amperage = parseFloat(data.Current);
+			if (data["ENERGY"].hasOwnProperty("Current")) {
+				that.amperage = parseFloat(data["ENERGY"].Current);
 				that.outletNowInUse = that.outletUseByCurrent ? (that.amperage > that.outletInUseCurrent) : true
 
 				that.service.setCharacteristic(EveAmperes, that.amperage);
 				that.service.setCharacteristic(Characteristic.OutletInUse, that.outletNowInUse);
 			}
-			that.todaykWh = data.hasOwnProperty("Today") ? parseFloat(data.Today) : -1;
+			that.todaykWh = data["ENERGY"].hasOwnProperty("Today") ? parseFloat(data["ENERGY"].Today) : -1;
 			// Preserve power data
 			if (that.patchToSave) {
 				that.fs.readFile(that.patchToSave + that.filename + "_powerTMP.txt", "utf8", function(err, data) {


### PR DESCRIPTION
Fix issues:  Does not work with Tasmota > 5.10; No Value and no log files
    
This is by adapting the tele/sonoff/SENSOR response (that contains power consumption infos) to that of the recent Tasmota 6.4.1 FW
    
Tested working with Eve Home App IOS

Verified csv power consumption logs are getting updated properly as well. 
